### PR TITLE
Changed compiler to clang.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ BINDIR ?= /usr/local/bin
 VERSION=$(shell git describe --tags --always)
 LIBPCAP_ARCH ?= x86_64-unknown-linux-gnu
 # For compiling libpcap and CGO
-CC ?= gcc
+CC ?= clang
 
 TEST_TIMEOUT ?= 5s
 .DEFAULT_GOAL := pwru
@@ -25,7 +25,7 @@ pwru: libpcap/libpcap.a
 ## Build libpcap for static linking
 libpcap/libpcap.a:
 	cd libpcap && \
-		CC=$(LIBPCAP_CC) ./configure --disable-rdma --disable-shared --disable-usb --disable-netmap --disable-bluetooth --disable-dbus --without-libnl --host=$(LIBPCAP_ARCH) && \
+		CC=$(CC) ./configure --disable-rdma --disable-shared --disable-usb --disable-netmap --disable-bluetooth --disable-dbus --without-libnl --host=$(LIBPCAP_ARCH) && \
 		make
 
 ## Build the GO binary within a Docker container


### PR DESCRIPTION


I have tested this on vm.
Test:
``` bash
sudo mv /usr/bin/gcc{,old}
make clean
make
```

verified binary is executable and running as expected.

Removed LIBPCAP_CC. As it indicates we are using different compilers.
I can revert it if needed.
